### PR TITLE
WIP packit support

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,20 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: fedora/python-fedorainfra-ansible-messages.spec
+
+# add or remove files that should be synced
+synced_files:
+    - python-fedorainfra-ansible-messages.spec
+    - .packit.yaml
+
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_package_name: fedorainfra-ansible-messages
+# downstream (Fedora) RPM package name
+downstream_package_name: python-fedorainfra-ansible-messages
+
+actions:
+  create-archive:
+    - python3 setup.py sdist --dist-dir ./fedora/
+    - bash -c "ls -1t ./fedora/*.tar.gz | head -n 1"
+  get-current-version: python3 setup.py --version

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,13 +5,12 @@ specfile_path: fedora/python-fedorainfra-ansible-messages.spec
 
 # add or remove files that should be synced
 synced_files:
-    - python-fedorainfra-ansible-messages.spec
     - .packit.yaml
 
 # name in upstream package repository/registry (e.g. in PyPI)
 upstream_package_name: fedorainfra-ansible-messages
 # downstream (Fedora) RPM package name
-downstream_package_name: python-fedorainfra-ansible-messages
+downstream_package_name: python-fedorainfra_ansible_messages
 
 actions:
   create-archive:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,3 +17,24 @@ actions:
     - python3 setup.py sdist --dist-dir ./fedora/
     - bash -c "ls -1t ./fedora/*.tar.gz | head -n 1"
   get-current-version: python3 setup.py --version
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - epel-8
+  - job: tests
+    trigger: pull_request
+    metadata:
+      targets:
+        - epel-8
+  - job: copr_build
+    trigger: commit
+    metadata:
+      branch: master
+      targets:
+        - epel-8
+      project: wip-fedorainfra-ansible-messages
+      list_on_homepage: False
+      preserve_project: False
+

--- a/fedora/python-fedorainfra-ansible-messages.spec
+++ b/fedora/python-fedorainfra-ansible-messages.spec
@@ -2,7 +2,7 @@
 
 Name:           python-fedorainfra_ansible_messages
 Version:        0.0.1
-Release:        0.20210122105014987741.packit_support.0.gbef3cd8%{?dist}
+Release:        0.20210125114029911485.packit_support.1.g44da197%{?dist}
 Summary:        Message schemas for fedorainfra messages produced by ansible 
 
 License:        MIT
@@ -11,11 +11,13 @@ Source0: fedorainfra_ansible-messages-0.0.1.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  cmake
+BuildRequires:  python3-devel
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
 BuildRequires:  python%{python3_pkgversion}-pytest
 BuildRequires:  python%{python3_pkgversion}-pytest-cov
+BuildRequires:  python%{python3_pkgversion}-fedora-messaging
 
 %description
 Message schemas for fedorainfra messages produced by ansible 
@@ -25,6 +27,7 @@ Message schemas for fedorainfra messages produced by ansible
 %package -n python3-%{srcname}
 Summary:        %{summary}
 
+Requires:  python%{python3_pkgversion}-fedora-messaging
 %if 0%{?fedora} < 33
 %{?python_provide:%python_provide python3-%{srcname}}
 %endif
@@ -49,12 +52,29 @@ rm -rf %{srcname}.egg-info
 %build
 %py3_build
 
+%check
+%{__python3} -m pytest
 
 %install
 %py3_install
 
 
 %changelog
+* Mon Jan 25 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210125114029911485.packit_support.1.g44da197
+- Builds localy, fails in copr (Adam Saleh)
+
+* Mon Jan 25 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210125112938233856.packit_support.1.g44da197
+- Builds localy, fails in copr (Adam Saleh)
+
+* Mon Jan 25 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210125112920274931.packit_support.1.g44da197
+- Builds localy, fails in copr (Adam Saleh)
+
+* Fri Jan 22 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210122111554358806.packit_support.1.g44da197
+- Builds localy, fails in copr (Adam Saleh)
+
+* Fri Jan 22 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210122105910630767.packit_support.1.g44da197
+- Builds localy, fails in copr (Adam Saleh)
+
 * Fri Jan 22 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210122105014987741.packit_support.0.gbef3cd8
 - Development snapshot (bef3cd88)
 

--- a/fedora/python-fedorainfra-ansible-messages.spec
+++ b/fedora/python-fedorainfra-ansible-messages.spec
@@ -1,18 +1,21 @@
-%global srcname python-fedorainfra-ansible-messages
+%global srcname fedorainfra_ansible_messages
 
-Name:           python-fedorainfra-ansible-messages
-Version:        1.0.0
-Release:        0.20210120083652209045.git.receive%{?dist}
+Name:           python-fedorainfra_ansible_messages
+Version:        0.0.1
+Release:        0.20210122105014987741.packit_support.0.gbef3cd8%{?dist}
 Summary:        Message schemas for fedorainfra messages produced by ansible 
 
 License:        MIT
 URL:            https://github.com/fedora-infra/fedorainfra-ansible-messages
-Source0:        %{pypi_source}
+Source0: fedorainfra_ansible-messages-0.0.1.tar.gz
 
 BuildArch:      noarch
+BuildRequires:  cmake
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
+BuildRequires:  python%{python3_pkgversion}-pytest
+BuildRequires:  python%{python3_pkgversion}-pytest-cov
 
 %description
 Message schemas for fedorainfra messages produced by ansible 
@@ -31,14 +34,14 @@ Message schemas for fedorainfra messages produced by ansible
 
 %files -n python3-%{srcname}
 %license LICENSE
-%doc README.rst
+%doc README.md
 %{python3_sitelib}/%{srcname}-*.egg-info
 %{python3_sitelib}/%{srcname}/
 
 #--------------------------------------------------------
 
 %prep
-%autosetup -n %{srcname}-%{version}
+%autosetup -n fedorainfra_ansible-messages-0.0.1
 # Remove bundled egg-info
 rm -rf %{srcname}.egg-info
 
@@ -51,10 +54,58 @@ rm -rf %{srcname}.egg-info
 %py3_install
 
 
-%check
-%{__python3} -m pytest
-
 %changelog
+* Fri Jan 22 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210122105014987741.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Fri Jan 22 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210122104824062495.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Fri Jan 22 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210122102242124904.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Thu Jan 21 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210121205822927991.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Thu Jan 21 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210121205704261270.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Thu Jan 21 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210121113922193408.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Thu Jan 21 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210121113309222085.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Thu Jan 21 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210121110536587288.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 0.0.1-0.20210120133759819590.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120133718369411.packit_support.0.gbef3cd8
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120133610948574.packit_support
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120132809627754.packit_support
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120131523376392.packit_support
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120131440385288.packit_support
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120131408385285.packit_support
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120130537464476.packit_support
+- Development snapshot (bef3cd88)
+
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120102837948955.packit_support
+- Development snapshot (bef3cd88)
+
 * Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120083652209045.git.receive
 - Development snapshot (dafb7c5e)
 

--- a/fedora/python-fedorainfra-ansible-messages.spec
+++ b/fedora/python-fedorainfra-ansible-messages.spec
@@ -1,0 +1,66 @@
+%global srcname python-fedorainfra-ansible-messages
+
+Name:           python-fedorainfra-ansible-messages
+Version:        1.0.0
+Release:        0.20210120083652209045.git.receive%{?dist}
+Summary:        Message schemas for fedorainfra messages produced by ansible 
+
+License:        MIT
+URL:            https://github.com/fedora-infra/fedorainfra-ansible-messages
+Source0:        %{pypi_source}
+
+BuildArch:      noarch
+BuildRequires:  python3dist(setuptools)
+BuildRequires:  python3dist(setuptools-scm)
+BuildRequires:  python3dist(setuptools-scm-git-archive)
+
+%description
+Message schemas for fedorainfra messages produced by ansible 
+
+# package the library
+
+%package -n python3-%{srcname}
+Summary:        %{summary}
+
+%if 0%{?fedora} < 33
+%{?python_provide:%python_provide python3-%{srcname}}
+%endif
+
+%description -n python3-%{srcname}
+Message schemas for fedorainfra messages produced by ansible 
+
+%files -n python3-%{srcname}
+%license LICENSE
+%doc README.rst
+%{python3_sitelib}/%{srcname}-*.egg-info
+%{python3_sitelib}/%{srcname}/
+
+#--------------------------------------------------------
+
+%prep
+%autosetup -n %{srcname}-%{version}
+# Remove bundled egg-info
+rm -rf %{srcname}.egg-info
+
+
+%build
+%py3_build
+
+
+%install
+%py3_install
+
+
+%check
+%{__python3} -m pytest
+
+%changelog
+* Wed Jan 20 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210120083652209045.git.receive
+- Development snapshot (dafb7c5e)
+
+* Tue Jan 19 2021 Adam Saleh <asaleh@redhat.com> - 1.0.0-0.20210119131915851563.git.receive
+- Development snapshot (dafb7c5e)
+
+* Wed Mar 18 2020  Adam Saleh <asaleh@redhat.com> - 0.0.1-1
+- initial package for EPEL
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fedorainfra_ansible-messages
-version = 1.0.0
+version = 0.0.1
 description = A schema package for messages sent by fedorainfra_ansible
 long_description = file: README.md
 url = https://github.com/fedora-infra/fedorainfra-ansible-messages


### PR DESCRIPTION
I want to use packit to produce the EPEL rpms to be then used within fedora-infra.

If this works, I would like to add this to our fedora-message schemas skeleton.